### PR TITLE
[FEAT]보관함 리스트 조회 API개발

### DIFF
--- a/growthookServer/.gitignore
+++ b/growthookServer/.gitignore
@@ -37,3 +37,5 @@ out/
 .vscode/
 
 resources
+../.DS_Store
+.DS_Store

--- a/growthookServer/build.gradle
+++ b/growthookServer/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 
     //* Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+    implementation 'org.springdoc:springdoc-openapi-ui:1.6.9'
 
     //* JWT
     implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'

--- a/growthookServer/src/main/java/com/example/growthookserver/api/HealthCheckController.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/HealthCheckController.java
@@ -1,12 +1,16 @@
 package com.example.growthookserver.api;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@Tag(name = "HealthCheck Controller", description = "HealthCheck API Document")
 public class HealthCheckController {
 
-    @GetMapping("/health")
+    @GetMapping("health")
+    @Operation(summary = "HealthCheck", description = "HealthCheck API입니다.")
     public String healthCheck() {
         return "OK";
     }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/cave/controller/CaveController.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/cave/controller/CaveController.java
@@ -1,6 +1,7 @@
 package com.example.growthookserver.api.cave.controller;
 
 import com.example.growthookserver.api.cave.dto.request.CaveCreateRequestDto;
+import com.example.growthookserver.api.cave.dto.response.CaveAllResponseDto;
 import com.example.growthookserver.api.cave.dto.response.CaveCreateResponseDto;
 import com.example.growthookserver.api.cave.service.CaveService;
 import com.example.growthookserver.common.response.ApiResponse;
@@ -10,6 +11,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,5 +25,11 @@ public class CaveController {
     @Operation(summary = "CavePost", description = "동굴 생성 API입니다.")
     public ApiResponse<CaveCreateResponseDto> createCave(@PathVariable("memberId") Long memberId, @Valid @RequestBody CaveCreateRequestDto caveCreateRequestDto) {
         return ApiResponse.success(SuccessStatus.POST_CAVE_SUCCESS, caveService.createCave(memberId, caveCreateRequestDto));
+    }
+
+    @GetMapping("member/{memberId}/cave/all")
+    @Operation(summary =  "CaveAllGet", description = "동굴 리스트를 가져오는 API입니다.")
+    public ApiResponse<CaveAllResponseDto> getCaveAll(@PathVariable Long memberId) {
+        return ApiResponse.success(SuccessStatus.GET_CAVE_ALL, caveService.getCaveAll(memberId));
     }
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/cave/controller/CaveController.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/cave/controller/CaveController.java
@@ -1,0 +1,26 @@
+package com.example.growthookserver.api.cave.controller;
+
+import com.example.growthookserver.api.cave.dto.request.CaveCreateRequestDto;
+import com.example.growthookserver.api.cave.dto.response.CaveCreateResponseDto;
+import com.example.growthookserver.api.cave.service.CaveService;
+import com.example.growthookserver.common.response.ApiResponse;
+import com.example.growthookserver.common.response.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1")
+@Tag(name = "Cave Controller", description = "Cave API Document")
+public class CaveController {
+    private final CaveService caveService;
+
+    @PostMapping("member/{memberId}/cave")
+    @Operation(summary = "CavePost", description = "동굴 생성 API입니다.")
+    public ApiResponse<CaveCreateResponseDto> createCave(@PathVariable("memberId") Long memberId, @Valid @RequestBody CaveCreateRequestDto caveCreateRequestDto) {
+        return ApiResponse.success(SuccessStatus.POST_CAVE_SUCCESS, caveService.createCave(memberId, caveCreateRequestDto));
+    }
+}

--- a/growthookServer/src/main/java/com/example/growthookserver/api/cave/dto/request/CaveCreateRequestDto.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/cave/dto/request/CaveCreateRequestDto.java
@@ -1,0 +1,19 @@
+package com.example.growthookserver.api.cave.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class CaveCreateRequestDto {
+    @NotBlank
+    private String name;
+    @NotBlank
+    private String introduction;
+    @NotBlank
+    private Boolean isShared;
+}

--- a/growthookServer/src/main/java/com/example/growthookserver/api/cave/dto/request/CaveCreateRequestDto.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/cave/dto/request/CaveCreateRequestDto.java
@@ -1,6 +1,7 @@
 package com.example.growthookserver.api.cave.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -14,6 +15,6 @@ public class CaveCreateRequestDto {
     private String name;
     @NotBlank
     private String introduction;
-    @NotBlank
+    @NotNull
     private Boolean isShared;
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/cave/dto/response/CaveAllResponseDto.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/cave/dto/response/CaveAllResponseDto.java
@@ -1,0 +1,18 @@
+package com.example.growthookserver.api.cave.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class CaveAllResponseDto {
+    private Long caveId;
+    private String caveName;
+
+    public static CaveAllResponseDto of(Long caveId, String caveName){
+        return new CaveAllResponseDto(caveId, caveName);
+    }
+}

--- a/growthookServer/src/main/java/com/example/growthookserver/api/cave/dto/response/CaveCreateResponseDto.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/cave/dto/response/CaveCreateResponseDto.java
@@ -1,0 +1,17 @@
+package com.example.growthookserver.api.cave.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class CaveCreateResponseDto {
+    private Long caveId;
+
+    public static CaveCreateResponseDto of(Long caveId){
+        return new CaveCreateResponseDto(caveId);
+    }
+}

--- a/growthookServer/src/main/java/com/example/growthookserver/api/cave/repository/CaveRepository.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/cave/repository/CaveRepository.java
@@ -3,5 +3,8 @@ package com.example.growthookserver.api.cave.repository;
 import com.example.growthookserver.api.cave.domain.Cave;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CaveRepository extends JpaRepository<Cave, Long> {
+    List<Cave> findAllByMemberId(Long memberId);
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/cave/repository/CaveRepository.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/cave/repository/CaveRepository.java
@@ -1,0 +1,7 @@
+package com.example.growthookserver.api.cave.repository;
+
+import com.example.growthookserver.api.cave.domain.Cave;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CaveRepository extends JpaRepository<Cave, Long> {
+}

--- a/growthookServer/src/main/java/com/example/growthookserver/api/cave/service/CaveService.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/cave/service/CaveService.java
@@ -1,0 +1,9 @@
+package com.example.growthookserver.api.cave.service;
+
+import com.example.growthookserver.api.cave.dto.request.CaveCreateRequestDto;
+import com.example.growthookserver.api.cave.dto.response.CaveCreateResponseDto;
+
+public interface CaveService {
+    //* 동굴 생성
+    CaveCreateResponseDto createCave(Long memberId, CaveCreateRequestDto caveCreateRequestDto);
+}

--- a/growthookServer/src/main/java/com/example/growthookserver/api/cave/service/CaveService.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/cave/service/CaveService.java
@@ -1,9 +1,15 @@
 package com.example.growthookserver.api.cave.service;
 
 import com.example.growthookserver.api.cave.dto.request.CaveCreateRequestDto;
+import com.example.growthookserver.api.cave.dto.response.CaveAllResponseDto;
 import com.example.growthookserver.api.cave.dto.response.CaveCreateResponseDto;
+
+import java.util.List;
 
 public interface CaveService {
     //* 동굴 생성
     CaveCreateResponseDto createCave(Long memberId, CaveCreateRequestDto caveCreateRequestDto);
+
+    //* 동굴 리스트 조회
+    List<CaveAllResponseDto> getCaveAll(Long memberId);
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/cave/service/Impl/CaveServiceImpl.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/cave/service/Impl/CaveServiceImpl.java
@@ -1,0 +1,40 @@
+package com.example.growthookserver.api.cave.service.Impl;
+
+import com.example.growthookserver.api.cave.domain.Cave;
+import com.example.growthookserver.api.cave.dto.request.CaveCreateRequestDto;
+import com.example.growthookserver.api.cave.dto.response.CaveCreateResponseDto;
+import com.example.growthookserver.api.cave.repository.CaveRepository;
+import com.example.growthookserver.api.cave.service.CaveService;
+import com.example.growthookserver.api.member.domain.Member;
+import com.example.growthookserver.api.member.repository.MemberRepository;
+import com.example.growthookserver.common.exception.NotFoundException;
+import com.example.growthookserver.common.response.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CaveServiceImpl implements CaveService {
+    private final MemberRepository memberRepository;
+    private final CaveRepository caveRepository;
+
+    @Override
+    @Transactional
+    public CaveCreateResponseDto createCave(Long memberId, CaveCreateRequestDto caveCreateRequestDto){
+        Member member = findMemberById(memberId);
+        Cave cave = Cave.builder()
+                .name(caveCreateRequestDto.getName())
+                .introduction(caveCreateRequestDto.getIntroduction())
+                .isShared(caveCreateRequestDto.getIsShared())
+                .member(member)
+                .build();
+        Cave savedCave = caveRepository.save(cave);
+        return CaveCreateResponseDto.of(savedCave.getId());
+    }
+
+    private Member findMemberById(Long memberId){
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.NOT_FOUND_MEMBER.getMessage()));
+    }
+}

--- a/growthookServer/src/main/java/com/example/growthookserver/api/cave/service/Impl/CaveServiceImpl.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/cave/service/Impl/CaveServiceImpl.java
@@ -2,6 +2,7 @@ package com.example.growthookserver.api.cave.service.Impl;
 
 import com.example.growthookserver.api.cave.domain.Cave;
 import com.example.growthookserver.api.cave.dto.request.CaveCreateRequestDto;
+import com.example.growthookserver.api.cave.dto.response.CaveAllResponseDto;
 import com.example.growthookserver.api.cave.dto.response.CaveCreateResponseDto;
 import com.example.growthookserver.api.cave.repository.CaveRepository;
 import com.example.growthookserver.api.cave.service.CaveService;
@@ -12,6 +13,9 @@ import com.example.growthookserver.common.response.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -31,6 +35,20 @@ public class CaveServiceImpl implements CaveService {
                 .build();
         Cave savedCave = caveRepository.save(cave);
         return CaveCreateResponseDto.of(savedCave.getId());
+    }
+
+    @Override
+    @Transactional
+    public List<CaveAllResponseDto> getCaveAll(Long memberId){
+        List<Cave> caves = caveRepository.findAllByMemberId(memberId);
+
+        if(caves.isEmpty()) {
+            throw new NotFoundException(ErrorStatus.NOT_FOUND_MEMBER_CAVE.getMessage());
+        }
+
+        return caves.stream()
+                .map(cave -> CaveAllResponseDto.of(cave.getId(), cave.getName()))
+                .collect(Collectors.toList());
     }
 
     private Member findMemberById(Long memberId){

--- a/growthookServer/src/main/java/com/example/growthookserver/api/member/repository/MemberRepository.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/member/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.example.growthookserver.api.member.repository;
+
+import com.example.growthookserver.api.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findMemberById(Long id);
+}

--- a/growthookServer/src/main/java/com/example/growthookserver/common/config/SecurityConfig.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/common/config/SecurityConfig.java
@@ -28,13 +28,19 @@ public class SecurityConfig {
     @Bean
     @Profile("dev")
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception{
-        XorCsrfTokenRequestAttributeHandler requestHandler = new XorCsrfTokenRequestAttributeHandler();
+        // XorCsrfTokenRequestAttributeHandler requestHandler = new XorCsrfTokenRequestAttributeHandler();
+//        http
+//                .csrf((csrf) -> csrf
+//                        .csrfTokenRequestHandler(requestHandler)
+//                )
+//                .authorizeRequests()
+//                .anyRequest().permitAll();
         http
-                .csrf((csrf) -> csrf
-                        .csrfTokenRequestHandler(requestHandler)
-                )
-                .authorizeRequests()
+                .csrf().disable()
+                .httpBasic().disable()
+                .authorizeHttpRequests()
                 .anyRequest().permitAll();
+
         return http.build();
     }
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/common/config/SwaggerConfig.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/common/config/SwaggerConfig.java
@@ -8,30 +8,18 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @OpenAPIDefinition(
-        info = @Info(title = "Grothook API 명세서",
-                description = "Grothook API 명세서",
+        info = @Info(title = "Growthook API 명세서",
+                description = "Growthook API 명세서",
                 version = "v1"))
 @RequiredArgsConstructor
 @Configuration
 public class SwaggerConfig {
 
     @Bean
-    public GroupedOpenApi chatOpenApi() {
-        String[] paths = {"/api/v1/**"};
-
+    public GroupedOpenApi Version1OpenApi() {
         return GroupedOpenApi.builder()
-                .group("Grothook API v1")
-                .pathsToMatch(paths)
-                .build();
-    }
-
-    @Bean
-    public GroupedOpenApi healthCheckOpenApi(){
-        String[] healthCheckPaths = {"/health"};
-
-        return GroupedOpenApi.builder()
-                .group("Health Check API")
-                .pathsToMatch(healthCheckPaths)
+                .group("Growthook API v1")
+                .pathsToMatch("/api/v1/**")
                 .build();
     }
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/common/config/SwaggerConfig.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/common/config/SwaggerConfig.java
@@ -1,0 +1,37 @@
+package com.example.growthookserver.common.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@OpenAPIDefinition(
+        info = @Info(title = "Grothook API 명세서",
+                description = "Grothook API 명세서",
+                version = "v1"))
+@RequiredArgsConstructor
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public GroupedOpenApi chatOpenApi() {
+        String[] paths = {"/api/v1/**"};
+
+        return GroupedOpenApi.builder()
+                .group("Grothook API v1")
+                .pathsToMatch(paths)
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi healthCheckOpenApi(){
+        String[] healthCheckPaths = {"/health"};
+
+        return GroupedOpenApi.builder()
+                .group("Health Check API")
+                .pathsToMatch(healthCheckPaths)
+                .build();
+    }
+}

--- a/growthookServer/src/main/java/com/example/growthookserver/common/response/ErrorStatus.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/common/response/ErrorStatus.java
@@ -29,6 +29,7 @@ public enum ErrorStatus {
      * 404 NOT_FOUND
      */
     NOT_FOUND_MEMBER("해당하는 유저가 없습니다."),
+    NOT_FOUND_MEMBER_CAVE("유저가 생성한 동굴이 없습니다."),
 
     /**
      * 500 SERVER_ERROR

--- a/growthookServer/src/main/java/com/example/growthookserver/common/response/ErrorStatus.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/common/response/ErrorStatus.java
@@ -28,7 +28,7 @@ public enum ErrorStatus {
     /**
      * 404 NOT_FOUND
      */
-
+    NOT_FOUND_MEMBER("해당하는 유저가 없습니다."),
 
     /**
      * 500 SERVER_ERROR

--- a/growthookServer/src/main/java/com/example/growthookserver/common/response/SuccessStatus.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/common/response/SuccessStatus.java
@@ -14,7 +14,12 @@ public enum SuccessStatus {
      */
     SIGNUP_SUCCESS(HttpStatus.CREATED, "회원가입 성공"),
     SIGNIN_SUCCESS(HttpStatus.OK, "로그인 성공"),
-    GET_NEW_TOKEN_SUCCESS(HttpStatus.OK,"토큰 재발급 성공")
+    GET_NEW_TOKEN_SUCCESS(HttpStatus.OK,"토큰 재발급 성공"),
+
+    /**
+     * cave
+     */
+    POST_CAVE_SUCCESS(HttpStatus.CREATED,"동굴 생성 성공")
     ;
 
     private final HttpStatus httpStatus;

--- a/growthookServer/src/main/java/com/example/growthookserver/common/response/SuccessStatus.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/common/response/SuccessStatus.java
@@ -19,7 +19,8 @@ public enum SuccessStatus {
     /**
      * cave
      */
-    POST_CAVE_SUCCESS(HttpStatus.CREATED,"동굴 생성 성공")
+    POST_CAVE_SUCCESS(HttpStatus.CREATED,"동굴 생성 성공"),
+    GET_CAVE_ALL(HttpStatus.OK,"동굴 목록 조회 성공")
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #9 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
보관함 리스트 조회 API를 개발했습니다. 예외 처리의 경우 해당 멤버의 cave가 없을 때에 대해서 했습니다.
실은 이때 response로 빈 배열을 반환하는게 맞을까 싶다가, 이전 퍼즐링 때에 따로 예외처리 하셨던 것 보고 참고했습니다.
변경된 파일
* CaveController -> GetMapping("member/{memberId}/cave/all")
* CaveRepository
* CaveService , CaveServiceImpl
* CaveAllResponseDto

<img width="1252" alt="스크린샷 2023-12-04 오전 12 54 10" src="https://github.com/Team-Growthook/Growthook-Server/assets/97835512/8bee1c37-bcb7-41b3-8da1-db77eb73b806">

<img width="1298" alt="스크린샷 2023-12-04 오전 12 54 27" src="https://github.com/Team-Growthook/Growthook-Server/assets/97835512/bce84654-55bc-492e-9123-038f5058e815">


## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
