### PR TITLE
#16 [FEAT] 씨앗 생성 API 개발

### DIFF
--- a/growthookServer/src/main/java/com/example/growthookserver/api/cave/controller/CaveController.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/cave/controller/CaveController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("api/v1")
-@Tag(name = "Cave Controller", description = "Cave API Document")
+@Tag(name = "Cave - 동굴 관련 API", description = "Cave API Document")
 public class CaveController {
     private final CaveService caveService;
 

--- a/growthookServer/src/main/java/com/example/growthookserver/api/cave/controller/CaveController.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/cave/controller/CaveController.java
@@ -12,7 +12,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.actuate.autoconfigure.observation.ObservationProperties;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 

--- a/growthookServer/src/main/java/com/example/growthookserver/api/cave/repository/CaveRepository.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/cave/repository/CaveRepository.java
@@ -1,6 +1,8 @@
 package com.example.growthookserver.api.cave.repository;
 
 import com.example.growthookserver.api.cave.domain.Cave;
+import com.example.growthookserver.common.exception.NotFoundException;
+import com.example.growthookserver.common.response.ErrorStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -10,4 +12,9 @@ public interface CaveRepository extends JpaRepository<Cave, Long> {
     List<Cave> findAllByMemberId(Long memberId);
 
     Optional<Cave> findCaveById(Long caveId);
+
+    default Cave findCaveByIdOrThrow(Long caveId) {
+        return findCaveById(caveId)
+            .orElseThrow(() -> new NotFoundException(ErrorStatus.NOT_FOUND_CAVE.getMessage()));
+    }
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/cave/service/Impl/CaveServiceImpl.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/cave/service/Impl/CaveServiceImpl.java
@@ -29,7 +29,7 @@ public class CaveServiceImpl implements CaveService {
     @Override
     @Transactional
     public CaveCreateResponseDto createCave(Long memberId, CaveCreateRequestDto caveCreateRequestDto){
-        Member member = findMemberById(memberId);
+        Member member = memberRepository.findMemberByIdOrThrow(memberId);
         Cave cave = Cave.builder()
                 .name(caveCreateRequestDto.getName())
                 .introduction(caveCreateRequestDto.getIntroduction())
@@ -52,14 +52,14 @@ public class CaveServiceImpl implements CaveService {
     @Override
     @Transactional
     public void updateCave(Long caveId, CaveUpdateRequestDto caveUpdateRequestDto){
-        Cave existingCave = findCaveById(caveId);
+        Cave existingCave = caveRepository.findCaveByIdOrThrow(caveId);
         existingCave.updateCave(caveUpdateRequestDto.getName(), caveUpdateRequestDto.getIntroduction(), caveUpdateRequestDto.getIsShared());
     }
 
     @Override
     public CaveDetailGetResponseDto getCaveDetail(Long memberId, Long caveId){
-        Member member = findMemberById(memberId);
-        Cave cave = findCaveById(caveId);
+        Member member = memberRepository.findMemberByIdOrThrow(memberId);
+        Cave cave = caveRepository.findCaveByIdOrThrow(caveId);
 
         return CaveDetailGetResponseDto.of(cave.getName(), cave.getIntroduction(), member.getNickname(), cave.getIsShared());
     }
@@ -67,17 +67,8 @@ public class CaveServiceImpl implements CaveService {
     @Override
     @Transactional
     public void deleteCave(Long caveID) {
-        Cave cave = findCaveById(caveID);
+        Cave cave = caveRepository.findCaveByIdOrThrow(caveID);
         caveRepository.delete(cave);
     }
 
-    private Member findMemberById(Long memberId){
-        return memberRepository.findById(memberId)
-                .orElseThrow(() -> new NotFoundException(ErrorStatus.NOT_FOUND_MEMBER.getMessage()));
-    }
-
-    private Cave findCaveById(Long caveId) {
-        return caveRepository.findCaveById(caveId)
-                .orElseThrow(() -> new NotFoundException(ErrorStatus.NOT_FOUND_CAVE.getMessage()));
-    }
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/member/repository/MemberRepository.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/member/repository/MemberRepository.java
@@ -1,10 +1,17 @@
 package com.example.growthookserver.api.member.repository;
 
 import com.example.growthookserver.api.member.domain.Member;
+import com.example.growthookserver.common.exception.NotFoundException;
+import com.example.growthookserver.common.response.ErrorStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findMemberById(Long id);
+
+    default Member findMemberByIdOrThrow(Long memberId){
+        return findMemberById(memberId)
+            .orElseThrow(() -> new NotFoundException(ErrorStatus.NOT_FOUND_MEMBER.getMessage()));
+    }
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/seed/controller/SeedController.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/seed/controller/SeedController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("api/v1")
-@Tag(name = "Seed Controller", description = "Seed API Document")
+@Tag(name = "Seed - 인사이트 관련 API", description = "Seed API Document")
 public class SeedController {
 
   private final SeedService seedService;

--- a/growthookServer/src/main/java/com/example/growthookserver/api/seed/controller/SeedController.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/seed/controller/SeedController.java
@@ -1,0 +1,38 @@
+package com.example.growthookserver.api.seed.controller;
+
+import com.example.growthookserver.api.cave.dto.request.CaveCreateRequestDto;
+import com.example.growthookserver.api.cave.dto.response.CaveCreateResponseDto;
+import com.example.growthookserver.api.seed.dto.request.SeedCreateRequestDto;
+import com.example.growthookserver.api.seed.dto.response.SeedCreateResponseDto;
+import com.example.growthookserver.api.seed.service.SeedService;
+import com.example.growthookserver.common.response.ApiResponse;
+import com.example.growthookserver.common.response.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1")
+@Tag(name = "Seed Controller", description = "Seed API Document")
+public class SeedController {
+
+  private final SeedService seedService;
+
+  @PostMapping("cave/{caveId}/seed")
+  @ResponseStatus(HttpStatus.CREATED)
+  @Operation(summary = "SeedPost", description = "씨앗 생성 API입니다.")
+  public ApiResponse<SeedCreateResponseDto> createSeed(@PathVariable("caveId") Long caveId, @Valid @RequestBody SeedCreateRequestDto seedCreateRequestDto) {
+    return ApiResponse.success(
+        SuccessStatus.POST_SEED_SUCCESS, seedService.createSeed(caveId, seedCreateRequestDto));
+  }
+
+}

--- a/growthookServer/src/main/java/com/example/growthookserver/api/seed/domain/Seed.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/seed/domain/Seed.java
@@ -48,14 +48,14 @@ public class Seed extends BaseTimeEntity {
     private List<ActionPlan> actionPlans = new ArrayList<>();
 
     @Builder
-    public Seed(String insight, String memo, String source, String url, LocalDate lockDate, Boolean isScraped, Boolean isLocked, Cave cave) {
+    public Seed(String insight, String memo, String source, String url, Integer goalMonth, Cave cave) {
         this.insight = insight;
         this.memo = memo;
         this.source = source;
         this.url = url;
-        this.lockDate = lockDate;
-        this.isScraped = isScraped;
-        this.isLocked = isLocked;
+        this.lockDate = LocalDate.now().plusDays(goalMonth * 30);
+        this.isScraped = false;
+        this.isLocked = false;
         this.cave = cave;
     }
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/seed/dto/request/SeedCreateRequestDto.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/seed/dto/request/SeedCreateRequestDto.java
@@ -1,0 +1,31 @@
+package com.example.growthookserver.api.seed.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(staticName = "of")
+public class SeedCreateRequestDto {
+  @NotBlank
+  @Size(max = 30)
+  private String insight;
+
+  @Size(max = 300)
+  private String memo;
+
+  @NotBlank
+  @Size(max = 20)
+  private String source;
+
+  private String url;
+
+  @NotNull
+  private Integer goalMonth;
+
+}

--- a/growthookServer/src/main/java/com/example/growthookserver/api/seed/dto/response/SeedCreateResponseDto.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/seed/dto/response/SeedCreateResponseDto.java
@@ -1,0 +1,13 @@
+package com.example.growthookserver.api.seed.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(staticName = "of")
+public class SeedCreateResponseDto {
+  private Long seedId;
+}

--- a/growthookServer/src/main/java/com/example/growthookserver/api/seed/repository/SeedRepository.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/seed/repository/SeedRepository.java
@@ -1,0 +1,9 @@
+package com.example.growthookserver.api.seed.repository;
+
+import com.example.growthookserver.api.cave.domain.Cave;
+import com.example.growthookserver.api.seed.domain.Seed;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SeedRepository extends JpaRepository<Seed, Long> {
+}

--- a/growthookServer/src/main/java/com/example/growthookserver/api/seed/service/Impl/SeedServiceImpl.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/seed/service/Impl/SeedServiceImpl.java
@@ -1,0 +1,38 @@
+package com.example.growthookserver.api.seed.service.Impl;
+
+import com.example.growthookserver.api.cave.domain.Cave;
+import com.example.growthookserver.api.cave.repository.CaveRepository;
+import com.example.growthookserver.api.seed.domain.Seed;
+import com.example.growthookserver.api.seed.dto.request.SeedCreateRequestDto;
+import com.example.growthookserver.api.seed.dto.response.SeedCreateResponseDto;
+import com.example.growthookserver.api.seed.repository.SeedRepository;
+import com.example.growthookserver.api.seed.service.SeedService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SeedServiceImpl implements SeedService {
+
+  private final CaveRepository caveRepository;
+  private final SeedRepository seedRepository;
+
+  @Override
+  @Transactional
+  public SeedCreateResponseDto createSeed(Long caveId, SeedCreateRequestDto seedCreateRequestDto) {
+    Cave cave = caveRepository.findCaveByIdOrThrow(caveId);
+    Seed seed = Seed.builder()
+        .cave(cave)
+        .memo(seedCreateRequestDto.getMemo())
+        .url(seedCreateRequestDto.getUrl())
+        .insight(seedCreateRequestDto.getInsight())
+        .source(seedCreateRequestDto.getSource())
+        .goalMonth(seedCreateRequestDto.getGoalMonth())
+        .build();
+    Seed savedSeed = seedRepository.save(seed);
+    return SeedCreateResponseDto.of(savedSeed.getId());
+  }
+
+}

--- a/growthookServer/src/main/java/com/example/growthookserver/api/seed/service/SeedService.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/seed/service/SeedService.java
@@ -1,0 +1,12 @@
+package com.example.growthookserver.api.seed.service;
+
+import com.example.growthookserver.api.cave.dto.request.CaveCreateRequestDto;
+import com.example.growthookserver.api.cave.dto.response.CaveCreateResponseDto;
+import com.example.growthookserver.api.seed.dto.request.SeedCreateRequestDto;
+import com.example.growthookserver.api.seed.dto.response.SeedCreateResponseDto;
+
+public interface SeedService {
+  //* 씨앗 생성
+  SeedCreateResponseDto createSeed(Long caveId, SeedCreateRequestDto seedCreateRequestDto);
+
+}

--- a/growthookServer/src/main/java/com/example/growthookserver/common/response/SuccessStatus.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/common/response/SuccessStatus.java
@@ -23,7 +23,12 @@ public enum SuccessStatus {
     GET_CAVE_ALL(HttpStatus.OK,"동굴 목록 조회 성공"),
     PATCH_CAVE_SUCCESS(HttpStatus.OK,"동굴 수정 성공"),
     GET_CAVE_DETAIL(HttpStatus.OK,"동굴 상세 정보 조회 성공"),
-    DELETE_CAVE(HttpStatus.OK,"동글 삭제 완료")
+    DELETE_CAVE(HttpStatus.OK,"동글 삭제 완료"),
+
+    /**
+     * seed
+     */
+    POST_SEED_SUCCESS(HttpStatus.CREATED, "씨앗 생성 성공"),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #16 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 인사이트 작성하는 API를 개발했습니다.
- 스웨거 문서에서 각 컨트롤러 단에 Tag 값을 이해하기 쉽게 writing을 바꿨습니다 !

<img width="1070" alt="image" src="https://github.com/Team-Growthook/Growthook-Server/assets/68415644/ab9279e6-bc11-4994-8ce1-f1550efa5022">


## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 기존에 각 서비스 단에서 repository를 통해 단건 조회를 해오고 Optional 값을 예외처리 하는 로직을 멤버 함수로 구현했었는데요. 여기 저기서 중복되어 사용되는 코드기도 하고, 서비스 덩치를 좀 줄이고자 리포지토리 interface에 Default methods로 구현해두었습니다 !
```
    default Cave findCaveByIdOrThrow(Long caveId) {
        return findCaveById(caveId)
            .orElseThrow(() -> new NotFoundException(ErrorStatus.NOT_FOUND_CAVE.getMessage()));
    }
```

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
