### PR TITLE
[FEAT]진행 중인 액션 플랜 목록 조회API 개발

### DIFF
--- a/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/controller/ActionPlanController.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/controller/ActionPlanController.java
@@ -1,0 +1,29 @@
+package com.example.growthookserver.api.actionplan.controller;
+
+import com.example.growthookserver.api.actionplan.dto.request.ActionPlanCreateRequestDto;
+import com.example.growthookserver.api.actionplan.dto.response.ActionPlanCreateResponseDto;
+import com.example.growthookserver.api.actionplan.service.ActionPlanService;
+import com.example.growthookserver.common.response.ApiResponse;
+import com.example.growthookserver.common.response.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1")
+@Tag(name = "AciontPlan - 액션플랜 관련 API",description = "AcitonPlan APi Documnet")
+public class ActionPlanController {
+
+    private final ActionPlanService actionPlanService;
+
+    @PostMapping("seed/{seedId}/actionPlan")
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "ActionPlanPost",description = "액션 플랜 생성 API입니다.")
+    public ApiResponse<ActionPlanCreateResponseDto> createActionPlan(@PathVariable("seedId")Long seedId, @Valid @RequestBody ActionPlanCreateRequestDto actionPlanCreateRequestDto) {
+        return ApiResponse.success(SuccessStatus.POST_ACTIONPLAN_SUCCESS, actionPlanService.createActionPlan(seedId, actionPlanCreateRequestDto));
+    }
+}

--- a/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/controller/ActionPlanController.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/controller/ActionPlanController.java
@@ -1,6 +1,7 @@
 package com.example.growthookserver.api.actionplan.controller;
 
 import com.example.growthookserver.api.actionplan.dto.request.ActionPlanCreateRequestDto;
+import com.example.growthookserver.api.actionplan.dto.request.ActionPlanUpdateRequestDto;
 import com.example.growthookserver.api.actionplan.dto.response.ActionPlanCreateResponseDto;
 import com.example.growthookserver.api.actionplan.dto.response.ActionPlanGetResponseDto;
 import com.example.growthookserver.api.actionplan.service.ActionPlanService;
@@ -33,5 +34,13 @@ public class ActionPlanController {
     @Operation(summary = "ActionPlanGet", description = "씨앗 별 액션 플랜 조회 API입니다.")
     public ApiResponse<ActionPlanGetResponseDto> getActionPlan(@PathVariable Long seedId) {
         return ApiResponse.success(SuccessStatus.GET_SEED_ACTIONPLAN_SUCCESS, actionPlanService.getActionPlan(seedId));
+    }
+
+    @PatchMapping("actionPlan/{actionPlanId}")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "ActionPlanPatch", description = "액션 플랜 내용을 수정하는 API입니다.")
+    public ApiResponse updateActionPlan(@PathVariable Long actionPlanId, @Valid @RequestBody ActionPlanUpdateRequestDto actionPlanUpdateRequestDto) {
+        actionPlanService.updateActionPlan(actionPlanId, actionPlanUpdateRequestDto);
+        return ApiResponse.success(SuccessStatus.PATCH_ACTIONPLAN_SUCCESS.getStatusCode(), SuccessStatus.PATCH_ACTIONPLAN_SUCCESS.getMessage());
     }
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/controller/ActionPlanController.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/controller/ActionPlanController.java
@@ -54,9 +54,16 @@ public class ActionPlanController {
 
     @PatchMapping("actionPlan/{actionPlanId}/completion")
     @ResponseStatus(HttpStatus.OK)
-    @Operation(summary = "ACtionPlanComplete", description = "액션 플랜을 완료하는 API입니다.")
+    @Operation(summary = "ActionPlanComplete", description = "액션 플랜을 완료하는 API입니다.")
     public ApiResponse completeActionPlan(@PathVariable Long actionPlanId) {
         actionPlanService.completeActionPlan(actionPlanId);
         return ApiResponse.success(SuccessStatus.COMPLETE_ACTIONPLAN_SUCCESS.getStatusCode(),SuccessStatus.COMPLETE_ACTIONPLAN_SUCCESS.getMessage());
+    }
+
+    @GetMapping("member/{memberId}/actionPlan/percent")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "ActionPlanPercent", description = "완료한 액션 플랜 퍼센트를 구하는 API입니다.")
+    public ApiResponse<Integer> getActionPlanPercent(@PathVariable Long memberId) {
+        return ApiResponse.success(SuccessStatus.GET_FINISHED_ACTIONPLAN_PERCENT, actionPlanService.getActionPlanPercent(memberId));
     }
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/controller/ActionPlanController.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/controller/ActionPlanController.java
@@ -43,4 +43,12 @@ public class ActionPlanController {
         actionPlanService.updateActionPlan(actionPlanId, actionPlanUpdateRequestDto);
         return ApiResponse.success(SuccessStatus.PATCH_ACTIONPLAN_SUCCESS.getStatusCode(), SuccessStatus.PATCH_ACTIONPLAN_SUCCESS.getMessage());
     }
+
+    @DeleteMapping("actionPlan/{actionPlanId}")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "ActionPlanDelete", description = "액션 플랜을 삭제하는 API입니다.")
+    public ApiResponse deleteActionPlan(@PathVariable Long actionPlanId) {
+        actionPlanService.deleteActionPlan(actionPlanId);
+        return ApiResponse.success(SuccessStatus.DELETE_ACTIONPLAN_SUCCESS.getStatusCode(), SuccessStatus.DELETE_ACTIONPLAN_SUCCESS.getMessage());
+    }
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/controller/ActionPlanController.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/controller/ActionPlanController.java
@@ -4,6 +4,7 @@ import com.example.growthookserver.api.actionplan.dto.request.ActionPlanCreateRe
 import com.example.growthookserver.api.actionplan.dto.request.ActionPlanUpdateRequestDto;
 import com.example.growthookserver.api.actionplan.dto.response.ActionPlanCreateResponseDto;
 import com.example.growthookserver.api.actionplan.dto.response.ActionPlanGetResponseDto;
+import com.example.growthookserver.api.actionplan.dto.response.DoingActionPlanGetResponseDto;
 import com.example.growthookserver.api.actionplan.service.ActionPlanService;
 import com.example.growthookserver.common.response.ApiResponse;
 import com.example.growthookserver.common.response.SuccessStatus;
@@ -65,5 +66,12 @@ public class ActionPlanController {
     @Operation(summary = "ActionPlanPercent", description = "완료한 액션 플랜 퍼센트를 구하는 API입니다.")
     public ApiResponse<Integer> getActionPlanPercent(@PathVariable Long memberId) {
         return ApiResponse.success(SuccessStatus.GET_FINISHED_ACTIONPLAN_PERCENT, actionPlanService.getActionPlanPercent(memberId));
+    }
+
+    @GetMapping("member/{memberId}/doing")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "DoingActionPlan", description = "진행 중인 액션 플랜 목록을 조회하는API입니다.")
+    public ApiResponse<DoingActionPlanGetResponseDto> getDoingActionPlan(@PathVariable Long memberId) {
+        return ApiResponse.success(SuccessStatus.GET_DOING_ACTIONPLAN_SUCCESS,actionPlanService.getDoingActionPlan(memberId));
     }
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/controller/ActionPlanController.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/controller/ActionPlanController.java
@@ -2,6 +2,7 @@ package com.example.growthookserver.api.actionplan.controller;
 
 import com.example.growthookserver.api.actionplan.dto.request.ActionPlanCreateRequestDto;
 import com.example.growthookserver.api.actionplan.dto.response.ActionPlanCreateResponseDto;
+import com.example.growthookserver.api.actionplan.dto.response.ActionPlanGetResponseDto;
 import com.example.growthookserver.api.actionplan.service.ActionPlanService;
 import com.example.growthookserver.common.response.ApiResponse;
 import com.example.growthookserver.common.response.SuccessStatus;
@@ -25,5 +26,12 @@ public class ActionPlanController {
     @Operation(summary = "ActionPlanPost",description = "액션 플랜 생성 API입니다.")
     public ApiResponse<ActionPlanCreateResponseDto> createActionPlan(@PathVariable("seedId")Long seedId, @Valid @RequestBody ActionPlanCreateRequestDto actionPlanCreateRequestDto) {
         return ApiResponse.success(SuccessStatus.POST_ACTIONPLAN_SUCCESS, actionPlanService.createActionPlan(seedId, actionPlanCreateRequestDto));
+    }
+
+    @GetMapping("seed/{seedId}/actionPlan")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "ActionPlanGet", description = "씨앗 별 액션 플랜 조회 API입니다.")
+    public ApiResponse<ActionPlanGetResponseDto> getActionPlan(@PathVariable Long seedId) {
+        return ApiResponse.success(SuccessStatus.GET_SEED_ACTIONPLAN_SUCCESS, actionPlanService.getActionPlan(seedId));
     }
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/controller/ActionPlanController.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/controller/ActionPlanController.java
@@ -51,4 +51,12 @@ public class ActionPlanController {
         actionPlanService.deleteActionPlan(actionPlanId);
         return ApiResponse.success(SuccessStatus.DELETE_ACTIONPLAN_SUCCESS.getStatusCode(), SuccessStatus.DELETE_ACTIONPLAN_SUCCESS.getMessage());
     }
+
+    @PatchMapping("actionPlan/{actionPlanId}/completion")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "ACtionPlanComplete", description = "액션 플랜을 완료하는 API입니다.")
+    public ApiResponse completeActionPlan(@PathVariable Long actionPlanId) {
+        actionPlanService.completeActionPlan(actionPlanId);
+        return ApiResponse.success(SuccessStatus.COMPLETE_ACTIONPLAN_SUCCESS.getStatusCode(),SuccessStatus.COMPLETE_ACTIONPLAN_SUCCESS.getMessage());
+    }
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/domain/ActionPlan.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/domain/ActionPlan.java
@@ -38,10 +38,10 @@ public class ActionPlan extends BaseTimeEntity {
     private List<Review> reviews = new ArrayList<>();
 
     @Builder
-    public ActionPlan(String content, Boolean isScraped, Boolean isFinished, Seed seed) {
+    public ActionPlan(String content, Seed seed) {
         this.content = content;
-        this.isScraped = isScraped;
-        this.isFinished = isFinished;
+        this.isScraped = false;
+        this.isFinished = false;
         this.seed = seed;
     }
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/domain/ActionPlan.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/domain/ActionPlan.java
@@ -44,4 +44,8 @@ public class ActionPlan extends BaseTimeEntity {
         this.isFinished = false;
         this.seed = seed;
     }
+
+    public void updateActionPlan(String newContent) {
+        this.content = newContent;
+    }
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/domain/ActionPlan.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/domain/ActionPlan.java
@@ -48,4 +48,8 @@ public class ActionPlan extends BaseTimeEntity {
     public void updateActionPlan(String newContent) {
         this.content = newContent;
     }
+
+    public void completeActionPlan(Boolean newIsFinished) {
+        this.isFinished = newIsFinished;
+    }
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/dto/request/ActionPlanCreateRequestDto.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/dto/request/ActionPlanCreateRequestDto.java
@@ -1,0 +1,17 @@
+package com.example.growthookserver.api.actionplan.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ActionPlanCreateRequestDto {
+    @NotBlank
+    @Size(max = 40)
+    private String content;
+}

--- a/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/dto/request/ActionPlanUpdateRequestDto.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/dto/request/ActionPlanUpdateRequestDto.java
@@ -1,0 +1,17 @@
+package com.example.growthookserver.api.actionplan.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ActionPlanUpdateRequestDto {
+    @NotBlank
+    @Size(max = 40)
+    private String content;
+}

--- a/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/dto/response/ActionPlanCreateResponseDto.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/dto/response/ActionPlanCreateResponseDto.java
@@ -1,0 +1,13 @@
+package com.example.growthookserver.api.actionplan.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(staticName = "of")
+public class ActionPlanCreateResponseDto {
+    private Long actionPlanId;
+}

--- a/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/dto/response/ActionPlanGetResponseDto.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/dto/response/ActionPlanGetResponseDto.java
@@ -8,7 +8,13 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(staticName = "of")
-public class ActionPlanCreateResponseDto {
+public class ActionPlanGetResponseDto {
 
     private Long actionPlanId;
+
+    private String content;
+
+    private Boolean isScraped;
+
+    private Boolean isFinished;
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/dto/response/DoingActionPlanGetResponseDto.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/dto/response/DoingActionPlanGetResponseDto.java
@@ -1,0 +1,15 @@
+package com.example.growthookserver.api.actionplan.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(staticName = "of")
+public class DoingActionPlanGetResponseDto {
+    private String content;
+    private Boolean isScraped;
+    private Long seedId;
+}

--- a/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/repository/ActionPlanRepository.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/repository/ActionPlanRepository.java
@@ -11,6 +11,8 @@ import java.util.Optional;
 
 public interface ActionPlanRepository extends JpaRepository<ActionPlan,Long> {
 
+    List<ActionPlan> findAllBySeedCaveMemberIdAndIsFinished(Long memberId, Boolean isFinished);
+
     @Query("SELECT ap FROM ActionPlan ap JOIN ap.seed s JOIN s.cave c JOIN c.member m WHERE m.id = :memberId")
     List<ActionPlan> findAllByMemberId(Long memberId);
     List<ActionPlan> findAllBySeedId(Long seedId);

--- a/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/repository/ActionPlanRepository.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/repository/ActionPlanRepository.java
@@ -1,10 +1,20 @@
 package com.example.growthookserver.api.actionplan.repository;
 
 import com.example.growthookserver.api.actionplan.domain.ActionPlan;
+import com.example.growthookserver.common.exception.NotFoundException;
+import com.example.growthookserver.common.response.ErrorStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ActionPlanRepository extends JpaRepository<ActionPlan,Long> {
     List<ActionPlan> findAllBySeedId(Long seedId);
+
+    Optional<ActionPlan> findActionPlanById(Long actionPlanId);
+
+    default ActionPlan findActionPlanByIdOrThrow(Long actionPlanId) {
+        return findActionPlanById(actionPlanId)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.NOT_FOUND_ACTIONPLAN.getMessage()));
+    }
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/repository/ActionPlanRepository.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/repository/ActionPlanRepository.java
@@ -1,0 +1,7 @@
+package com.example.growthookserver.api.actionplan.repository;
+
+import com.example.growthookserver.api.actionplan.domain.ActionPlan;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ActionPlanRepository extends JpaRepository<ActionPlan,Long> {
+}

--- a/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/repository/ActionPlanRepository.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/repository/ActionPlanRepository.java
@@ -4,11 +4,15 @@ import com.example.growthookserver.api.actionplan.domain.ActionPlan;
 import com.example.growthookserver.common.exception.NotFoundException;
 import com.example.growthookserver.common.response.ErrorStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface ActionPlanRepository extends JpaRepository<ActionPlan,Long> {
+
+    @Query("SELECT ap FROM ActionPlan ap JOIN ap.seed s JOIN s.cave c JOIN c.member m WHERE m.id = :memberId")
+    List<ActionPlan> findAllByMemberId(Long memberId);
     List<ActionPlan> findAllBySeedId(Long seedId);
 
     Optional<ActionPlan> findActionPlanById(Long actionPlanId);

--- a/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/repository/ActionPlanRepository.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/repository/ActionPlanRepository.java
@@ -3,5 +3,8 @@ package com.example.growthookserver.api.actionplan.repository;
 import com.example.growthookserver.api.actionplan.domain.ActionPlan;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ActionPlanRepository extends JpaRepository<ActionPlan,Long> {
+    List<ActionPlan> findAllBySeedId(Long seedId);
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/service/ActionPlanService.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/service/ActionPlanService.java
@@ -4,6 +4,7 @@ import com.example.growthookserver.api.actionplan.dto.request.ActionPlanCreateRe
 import com.example.growthookserver.api.actionplan.dto.request.ActionPlanUpdateRequestDto;
 import com.example.growthookserver.api.actionplan.dto.response.ActionPlanCreateResponseDto;
 import com.example.growthookserver.api.actionplan.dto.response.ActionPlanGetResponseDto;
+import com.example.growthookserver.api.actionplan.dto.response.DoingActionPlanGetResponseDto;
 
 import java.util.List;
 
@@ -25,4 +26,6 @@ public interface ActionPlanService {
 
     //* 액션 플랜 달성 퍼센트 조회
     int getActionPlanPercent(Long memberId);
+
+    List<DoingActionPlanGetResponseDto> getDoingActionPlan(Long memberId);
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/service/ActionPlanService.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/service/ActionPlanService.java
@@ -16,4 +16,7 @@ public interface ActionPlanService {
 
     //* 액션 플랜 수정
     void updateActionPlan(Long actionPlanId, ActionPlanUpdateRequestDto actionPlanUpdateRequestDto);
+
+    //* 액션 플랜 삭제
+    void deleteActionPlan(Long actionPlanId);
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/service/ActionPlanService.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/service/ActionPlanService.java
@@ -1,0 +1,9 @@
+package com.example.growthookserver.api.actionplan.service;
+
+import com.example.growthookserver.api.actionplan.dto.request.ActionPlanCreateRequestDto;
+import com.example.growthookserver.api.actionplan.dto.response.ActionPlanCreateResponseDto;
+
+public interface ActionPlanService {
+    //* 액션플랜 생성
+    ActionPlanCreateResponseDto createActionPlan(Long seedId, ActionPlanCreateRequestDto actionPlanCreateRequestDto);
+}

--- a/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/service/ActionPlanService.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/service/ActionPlanService.java
@@ -2,8 +2,14 @@ package com.example.growthookserver.api.actionplan.service;
 
 import com.example.growthookserver.api.actionplan.dto.request.ActionPlanCreateRequestDto;
 import com.example.growthookserver.api.actionplan.dto.response.ActionPlanCreateResponseDto;
+import com.example.growthookserver.api.actionplan.dto.response.ActionPlanGetResponseDto;
+
+import java.util.List;
 
 public interface ActionPlanService {
     //* 액션플랜 생성
     ActionPlanCreateResponseDto createActionPlan(Long seedId, ActionPlanCreateRequestDto actionPlanCreateRequestDto);
+
+    //* 씨앗 별 액션 플랜 조회
+    List<ActionPlanGetResponseDto> getActionPlan(Long seedId);
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/service/ActionPlanService.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/service/ActionPlanService.java
@@ -22,4 +22,7 @@ public interface ActionPlanService {
 
     //* 액션 플랜 완료 토글
     void completeActionPlan(Long actionPlanId);
+
+    //* 액션 플랜 달성 퍼센트 조회
+    int getActionPlanPercent(Long memberId);
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/service/ActionPlanService.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/service/ActionPlanService.java
@@ -1,6 +1,7 @@
 package com.example.growthookserver.api.actionplan.service;
 
 import com.example.growthookserver.api.actionplan.dto.request.ActionPlanCreateRequestDto;
+import com.example.growthookserver.api.actionplan.dto.request.ActionPlanUpdateRequestDto;
 import com.example.growthookserver.api.actionplan.dto.response.ActionPlanCreateResponseDto;
 import com.example.growthookserver.api.actionplan.dto.response.ActionPlanGetResponseDto;
 
@@ -12,4 +13,7 @@ public interface ActionPlanService {
 
     //* 씨앗 별 액션 플랜 조회
     List<ActionPlanGetResponseDto> getActionPlan(Long seedId);
+
+    //* 액션 플랜 수정
+    void updateActionPlan(Long actionPlanId, ActionPlanUpdateRequestDto actionPlanUpdateRequestDto);
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/service/ActionPlanService.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/service/ActionPlanService.java
@@ -19,4 +19,7 @@ public interface ActionPlanService {
 
     //* 액션 플랜 삭제
     void deleteActionPlan(Long actionPlanId);
+
+    //* 액션 플랜 완료 토글
+    void completeActionPlan(Long actionPlanId);
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/service/Impl/ActionPlanServiceImpl.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/service/Impl/ActionPlanServiceImpl.java
@@ -13,6 +13,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -61,8 +63,25 @@ public class ActionPlanServiceImpl implements ActionPlanService {
 
     @Override
     @Transactional
-    public void completeActionPlan(Long aactionPlanId) {
-        ActionPlan existinActionPlan = actionPlanRepository.findActionPlanByIdOrThrow(aactionPlanId);
+    public void completeActionPlan(Long actionPlanId) {
+        ActionPlan existinActionPlan = actionPlanRepository.findActionPlanByIdOrThrow(actionPlanId);
         existinActionPlan.completeActionPlan(true);
+    }
+
+    @Override
+    public int getActionPlanPercent(Long memberId) {
+        List<ActionPlan> allActionPlans = actionPlanRepository.findAllByMemberId(memberId);
+        long totalActionPlans = allActionPlans.size();
+
+        if(totalActionPlans == 0) {
+            return 0;
+        }
+
+        long finishedActionPlan = allActionPlans.stream().filter(ActionPlan::getIsFinished).count();
+        System.out.println(totalActionPlans);
+        System.out.println(finishedActionPlan);
+        double ratio = (double) finishedActionPlan / totalActionPlans;
+        BigDecimal roundedRatio = BigDecimal.valueOf(ratio * 100.0).setScale(1, RoundingMode.HALF_UP);
+        return roundedRatio.intValue();
     }
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/service/Impl/ActionPlanServiceImpl.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/service/Impl/ActionPlanServiceImpl.java
@@ -2,6 +2,7 @@ package com.example.growthookserver.api.actionplan.service.Impl;
 
 import com.example.growthookserver.api.actionplan.domain.ActionPlan;
 import com.example.growthookserver.api.actionplan.dto.request.ActionPlanCreateRequestDto;
+import com.example.growthookserver.api.actionplan.dto.request.ActionPlanUpdateRequestDto;
 import com.example.growthookserver.api.actionplan.dto.response.ActionPlanCreateResponseDto;
 import com.example.growthookserver.api.actionplan.dto.response.ActionPlanGetResponseDto;
 import com.example.growthookserver.api.actionplan.repository.ActionPlanRepository;
@@ -42,5 +43,12 @@ public class ActionPlanServiceImpl implements ActionPlanService {
         return actionPlans.stream()
                 .map(actionPlan -> ActionPlanGetResponseDto.of(actionPlan.getId(), actionPlan.getContent(), actionPlan.getIsScraped(), actionPlan.getIsFinished()))
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public void updateActionPlan(Long actionPlanId, ActionPlanUpdateRequestDto actionPlanUpdateRequestDto) {
+        ActionPlan existingActionPlan = actionPlanRepository.findActionPlanByIdOrThrow(actionPlanId);
+        existingActionPlan.updateActionPlan(actionPlanUpdateRequestDto.getContent());
     }
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/service/Impl/ActionPlanServiceImpl.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/service/Impl/ActionPlanServiceImpl.java
@@ -58,4 +58,11 @@ public class ActionPlanServiceImpl implements ActionPlanService {
         ActionPlan exisitngActionPlan = actionPlanRepository.findActionPlanByIdOrThrow(actionPlanId);
         actionPlanRepository.delete(exisitngActionPlan);
     }
+
+    @Override
+    @Transactional
+    public void completeActionPlan(Long aactionPlanId) {
+        ActionPlan existinActionPlan = actionPlanRepository.findActionPlanByIdOrThrow(aactionPlanId);
+        existinActionPlan.completeActionPlan(true);
+    }
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/service/Impl/ActionPlanServiceImpl.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/service/Impl/ActionPlanServiceImpl.java
@@ -3,6 +3,7 @@ package com.example.growthookserver.api.actionplan.service.Impl;
 import com.example.growthookserver.api.actionplan.domain.ActionPlan;
 import com.example.growthookserver.api.actionplan.dto.request.ActionPlanCreateRequestDto;
 import com.example.growthookserver.api.actionplan.dto.response.ActionPlanCreateResponseDto;
+import com.example.growthookserver.api.actionplan.dto.response.ActionPlanGetResponseDto;
 import com.example.growthookserver.api.actionplan.repository.ActionPlanRepository;
 import com.example.growthookserver.api.actionplan.service.ActionPlanService;
 import com.example.growthookserver.api.seed.domain.Seed;
@@ -10,6 +11,9 @@ import com.example.growthookserver.api.seed.repository.SeedRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -29,5 +33,14 @@ public class ActionPlanServiceImpl implements ActionPlanService {
                 .build();
         ActionPlan savedActionPlan = actionPlanRepository.save(actionPlan);
         return ActionPlanCreateResponseDto.of(savedActionPlan.getId());
+    }
+
+    @Override
+    public List<ActionPlanGetResponseDto> getActionPlan(Long seedId) {
+        List<ActionPlan> actionPlans = actionPlanRepository.findAllBySeedId(seedId);
+
+        return actionPlans.stream()
+                .map(actionPlan -> ActionPlanGetResponseDto.of(actionPlan.getId(), actionPlan.getContent(), actionPlan.getIsScraped(), actionPlan.getIsFinished()))
+                .collect(Collectors.toList());
     }
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/service/Impl/ActionPlanServiceImpl.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/service/Impl/ActionPlanServiceImpl.java
@@ -51,4 +51,11 @@ public class ActionPlanServiceImpl implements ActionPlanService {
         ActionPlan existingActionPlan = actionPlanRepository.findActionPlanByIdOrThrow(actionPlanId);
         existingActionPlan.updateActionPlan(actionPlanUpdateRequestDto.getContent());
     }
+
+    @Override
+    @Transactional
+    public void deleteActionPlan(Long actionPlanId) {
+        ActionPlan exisitngActionPlan = actionPlanRepository.findActionPlanByIdOrThrow(actionPlanId);
+        actionPlanRepository.delete(exisitngActionPlan);
+    }
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/service/Impl/ActionPlanServiceImpl.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/service/Impl/ActionPlanServiceImpl.java
@@ -1,0 +1,33 @@
+package com.example.growthookserver.api.actionplan.service.Impl;
+
+import com.example.growthookserver.api.actionplan.domain.ActionPlan;
+import com.example.growthookserver.api.actionplan.dto.request.ActionPlanCreateRequestDto;
+import com.example.growthookserver.api.actionplan.dto.response.ActionPlanCreateResponseDto;
+import com.example.growthookserver.api.actionplan.repository.ActionPlanRepository;
+import com.example.growthookserver.api.actionplan.service.ActionPlanService;
+import com.example.growthookserver.api.seed.domain.Seed;
+import com.example.growthookserver.api.seed.repository.SeedRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ActionPlanServiceImpl implements ActionPlanService {
+
+    private final ActionPlanRepository actionPlanRepository;
+    private final SeedRepository seedRepository;
+
+    @Override
+    @Transactional
+    public ActionPlanCreateResponseDto createActionPlan(Long seedId, ActionPlanCreateRequestDto actionPlanCreateRequestDto){
+        Seed seed = seedRepository.findSeedByIdOrThrow(seedId);
+        ActionPlan actionPlan = ActionPlan.builder()
+                .content(actionPlanCreateRequestDto.getContent())
+                .seed(seed)
+                .build();
+        ActionPlan savedActionPlan = actionPlanRepository.save(actionPlan);
+        return ActionPlanCreateResponseDto.of(savedActionPlan.getId());
+    }
+}

--- a/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/service/Impl/ActionPlanServiceImpl.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/service/Impl/ActionPlanServiceImpl.java
@@ -5,6 +5,7 @@ import com.example.growthookserver.api.actionplan.dto.request.ActionPlanCreateRe
 import com.example.growthookserver.api.actionplan.dto.request.ActionPlanUpdateRequestDto;
 import com.example.growthookserver.api.actionplan.dto.response.ActionPlanCreateResponseDto;
 import com.example.growthookserver.api.actionplan.dto.response.ActionPlanGetResponseDto;
+import com.example.growthookserver.api.actionplan.dto.response.DoingActionPlanGetResponseDto;
 import com.example.growthookserver.api.actionplan.repository.ActionPlanRepository;
 import com.example.growthookserver.api.actionplan.service.ActionPlanService;
 import com.example.growthookserver.api.seed.domain.Seed;
@@ -83,5 +84,14 @@ public class ActionPlanServiceImpl implements ActionPlanService {
         double ratio = (double) finishedActionPlan / totalActionPlans;
         BigDecimal roundedRatio = BigDecimal.valueOf(ratio * 100.0).setScale(1, RoundingMode.HALF_UP);
         return roundedRatio.intValue();
+    }
+
+    @Override
+    public List<DoingActionPlanGetResponseDto> getDoingActionPlan(Long memberId) {
+        List<ActionPlan> doingActionPlans = actionPlanRepository.findAllBySeedCaveMemberIdAndIsFinished(memberId,false);
+
+        return doingActionPlans.stream()
+                .map(actionPlan -> DoingActionPlanGetResponseDto.of(actionPlan.getContent(), actionPlan.getIsScraped(),actionPlan.getSeed().getId()))
+                .collect(Collectors.toList());
     }
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/seed/repository/SeedRepository.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/seed/repository/SeedRepository.java
@@ -12,6 +12,6 @@ public interface SeedRepository extends JpaRepository<Seed, Long> {
 
   default Seed findSeedByIdOrThrow(Long seedId) {
     return findSeedById(seedId)
-        .orElseThrow(()-> new NotFoundException(ErrorStatus.NOT_FOUND_CAVE.getMessage()));
+        .orElseThrow(()-> new NotFoundException(ErrorStatus.NOT_FOUND_SEED.getMessage()));
   }
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/common/response/ErrorStatus.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/common/response/ErrorStatus.java
@@ -32,6 +32,7 @@ public enum ErrorStatus {
     NOT_FOUND_MEMBER_CAVE("유저가 생성한 동굴이 없습니다."),
     NOT_FOUND_CAVE("해당하는 동굴이 없습니다."),
     NOT_FOUND_SEED("해당하는 씨앗이 없습니다."),
+    NOT_FOUND_ACTIONPLAN("해당하는 액션 플랜이 없습니다."),
 
     /**
      * 500 SERVER_ERROR

--- a/growthookServer/src/main/java/com/example/growthookserver/common/response/SuccessStatus.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/common/response/SuccessStatus.java
@@ -30,6 +30,11 @@ public enum SuccessStatus {
      */
     POST_SEED_SUCCESS(HttpStatus.CREATED, "씨앗 생성 성공"),
     DELETE_SEED(HttpStatus.OK, "씨앗 삭제 성공"),
+
+    /**
+     * actionplan
+     */
+    POST_ACTIONPLAN_SUCCESS(HttpStatus.CREATED, "액션 플랜 생성 성공")
     ;
 
     private final HttpStatus httpStatus;

--- a/growthookServer/src/main/java/com/example/growthookserver/common/response/SuccessStatus.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/common/response/SuccessStatus.java
@@ -39,7 +39,8 @@ public enum SuccessStatus {
     PATCH_ACTIONPLAN_SUCCESS(HttpStatus.OK, "액션 플랜 수정 성공"),
     DELETE_ACTIONPLAN_SUCCESS(HttpStatus.OK,"액션 플랜 삭제 성공"),
     COMPLETE_ACTIONPLAN_SUCCESS(HttpStatus.OK, "액션 플랜 완료하기 성공"),
-    GET_FINISHED_ACTIONPLAN_PERCENT(HttpStatus.OK, "완료한 액션 플랜 퍼센트 조회 성공")
+    GET_FINISHED_ACTIONPLAN_PERCENT(HttpStatus.OK, "완료한 액션 플랜 퍼센트 조회 성공"),
+    GET_DOING_ACTIONPLAN_SUCCESS(HttpStatus.OK, "진행 중인 액션 플랜 리스트 조회 성공")
     ;
 
     private final HttpStatus httpStatus;

--- a/growthookServer/src/main/java/com/example/growthookserver/common/response/SuccessStatus.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/common/response/SuccessStatus.java
@@ -35,7 +35,8 @@ public enum SuccessStatus {
      * actionplan
      */
     POST_ACTIONPLAN_SUCCESS(HttpStatus.CREATED, "액션 플랜 생성 성공"),
-    GET_SEED_ACTIONPLAN_SUCCESS(HttpStatus.OK, "씨앗 별 액션 플랜 조회 성공")
+    GET_SEED_ACTIONPLAN_SUCCESS(HttpStatus.OK, "씨앗 별 액션 플랜 조회 성공"),
+    PATCH_ACTIONPLAN_SUCCESS(HttpStatus.OK, "액션 플랜 수정 성공")
     ;
 
     private final HttpStatus httpStatus;

--- a/growthookServer/src/main/java/com/example/growthookserver/common/response/SuccessStatus.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/common/response/SuccessStatus.java
@@ -36,7 +36,8 @@ public enum SuccessStatus {
      */
     POST_ACTIONPLAN_SUCCESS(HttpStatus.CREATED, "액션 플랜 생성 성공"),
     GET_SEED_ACTIONPLAN_SUCCESS(HttpStatus.OK, "씨앗 별 액션 플랜 조회 성공"),
-    PATCH_ACTIONPLAN_SUCCESS(HttpStatus.OK, "액션 플랜 수정 성공")
+    PATCH_ACTIONPLAN_SUCCESS(HttpStatus.OK, "액션 플랜 수정 성공"),
+    DELETE_ACTIONPLAN_SUCCESS(HttpStatus.OK,"액션 플랜 삭제 성공")
     ;
 
     private final HttpStatus httpStatus;

--- a/growthookServer/src/main/java/com/example/growthookserver/common/response/SuccessStatus.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/common/response/SuccessStatus.java
@@ -34,7 +34,8 @@ public enum SuccessStatus {
     /**
      * actionplan
      */
-    POST_ACTIONPLAN_SUCCESS(HttpStatus.CREATED, "액션 플랜 생성 성공")
+    POST_ACTIONPLAN_SUCCESS(HttpStatus.CREATED, "액션 플랜 생성 성공"),
+    GET_SEED_ACTIONPLAN_SUCCESS(HttpStatus.OK, "씨앗 별 액션 플랜 조회 성공")
     ;
 
     private final HttpStatus httpStatus;

--- a/growthookServer/src/main/java/com/example/growthookserver/common/response/SuccessStatus.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/common/response/SuccessStatus.java
@@ -37,7 +37,8 @@ public enum SuccessStatus {
     POST_ACTIONPLAN_SUCCESS(HttpStatus.CREATED, "액션 플랜 생성 성공"),
     GET_SEED_ACTIONPLAN_SUCCESS(HttpStatus.OK, "씨앗 별 액션 플랜 조회 성공"),
     PATCH_ACTIONPLAN_SUCCESS(HttpStatus.OK, "액션 플랜 수정 성공"),
-    DELETE_ACTIONPLAN_SUCCESS(HttpStatus.OK,"액션 플랜 삭제 성공")
+    DELETE_ACTIONPLAN_SUCCESS(HttpStatus.OK,"액션 플랜 삭제 성공"),
+    COMPLETE_ACTIONPLAN_SUCCESS(HttpStatus.OK, "액션 플랜 완료하기 성공")
     ;
 
     private final HttpStatus httpStatus;

--- a/growthookServer/src/main/java/com/example/growthookserver/common/response/SuccessStatus.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/common/response/SuccessStatus.java
@@ -38,7 +38,8 @@ public enum SuccessStatus {
     GET_SEED_ACTIONPLAN_SUCCESS(HttpStatus.OK, "씨앗 별 액션 플랜 조회 성공"),
     PATCH_ACTIONPLAN_SUCCESS(HttpStatus.OK, "액션 플랜 수정 성공"),
     DELETE_ACTIONPLAN_SUCCESS(HttpStatus.OK,"액션 플랜 삭제 성공"),
-    COMPLETE_ACTIONPLAN_SUCCESS(HttpStatus.OK, "액션 플랜 완료하기 성공")
+    COMPLETE_ACTIONPLAN_SUCCESS(HttpStatus.OK, "액션 플랜 완료하기 성공"),
+    GET_FINISHED_ACTIONPLAN_PERCENT(HttpStatus.OK, "완료한 액션 플랜 퍼센트 조회 성공")
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #31 

위에 POSTMAN사진에는 액션 플랜에 대한 Id값은 없는데, 다음 API작업하면서 생각해보니 있어야 겠다 싶어서 다음 API에 대한 PR에는 액션플랜 Id도 같이 반환하도록 수정했습니다. 참고 부탁드립니다. 감사합니당!!

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
* 진행 중인 액션 플랜 목록을 조회하는 API를 개발했습니다.
<img width="1302" alt="스크린샷 2023-12-20 오전 5 23 01" src="https://github.com/Team-Growthook/Growthook-Server/assets/97835512/a4db3d07-0f8d-40d1-8483-9ec341615907">


## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
이 API를 만들면서 "진행 중인"에 대한 의미로 "doing"이라는 표현을 썼는데 진짜 너무 구린거 같은데 마땅한게 생각이 안나요...뇌용량 이슈 ㅜ뭐가 좋을까요?

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
