### PR TITLE
[FEAT] 회원 탈퇴 API

### DIFF
--- a/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/controller/ActionPlanController.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/actionplan/controller/ActionPlanController.java
@@ -23,7 +23,7 @@ public class ActionPlanController {
 
     private final ActionPlanService actionPlanService;
 
-    @PostMapping("seed/{seedId}/actionPlan")
+    @PostMapping("seed/{seedId}/actionplan")
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "ActionPlanPost",description = "액션 플랜 생성 API입니다.")
     public ApiResponse createActionPlan(@PathVariable("seedId")Long seedId, @Valid @RequestBody ActionPlanCreateRequestDto actionPlanCreateRequestDto) {
@@ -31,14 +31,14 @@ public class ActionPlanController {
         return ApiResponse.success(SuccessStatus.POST_ACTIONPLAN_SUCCESS.getStatusCode(), SuccessStatus.POST_ACTIONPLAN_SUCCESS.getMessage());
     }
 
-    @GetMapping("seed/{seedId}/actionPlan")
+    @GetMapping("seed/{seedId}/actionplan")
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "ActionPlanGet", description = "씨앗 별 액션 플랜 조회 API입니다.")
     public ApiResponse<ActionPlanGetResponseDto> getActionPlan(@PathVariable Long seedId) {
         return ApiResponse.success(SuccessStatus.GET_SEED_ACTIONPLAN_SUCCESS, actionPlanService.getActionPlan(seedId));
     }
 
-    @PatchMapping("actionPlan/{actionPlanId}")
+    @PatchMapping("actionplan/{actionPlanId}")
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "ActionPlanPatch", description = "액션 플랜 내용을 수정하는 API입니다.")
     public ApiResponse updateActionPlan(@PathVariable Long actionPlanId, @Valid @RequestBody ActionPlanUpdateRequestDto actionPlanUpdateRequestDto) {
@@ -46,7 +46,7 @@ public class ActionPlanController {
         return ApiResponse.success(SuccessStatus.PATCH_ACTIONPLAN_SUCCESS.getStatusCode(), SuccessStatus.PATCH_ACTIONPLAN_SUCCESS.getMessage());
     }
 
-    @DeleteMapping("actionPlan/{actionPlanId}")
+    @DeleteMapping("actionplan/{actionPlanId}")
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "ActionPlanDelete", description = "액션 플랜을 삭제하는 API입니다.")
     public ApiResponse deleteActionPlan(@PathVariable Long actionPlanId) {
@@ -54,7 +54,7 @@ public class ActionPlanController {
         return ApiResponse.success(SuccessStatus.DELETE_ACTIONPLAN_SUCCESS.getStatusCode(), SuccessStatus.DELETE_ACTIONPLAN_SUCCESS.getMessage());
     }
 
-    @PatchMapping("actionPlan/{actionPlanId}/completion")
+    @PatchMapping("actionplan/{actionPlanId}/completion")
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "ActionPlanComplete", description = "액션 플랜을 완료하는 API입니다.")
     public ApiResponse completeActionPlan(@PathVariable Long actionPlanId) {
@@ -62,7 +62,7 @@ public class ActionPlanController {
         return ApiResponse.success(SuccessStatus.COMPLETE_ACTIONPLAN_SUCCESS.getStatusCode(),SuccessStatus.COMPLETE_ACTIONPLAN_SUCCESS.getMessage());
     }
 
-    @GetMapping("member/{memberId}/actionPlan/percent")
+    @GetMapping("member/{memberId}/actionplan/percent")
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "ActionPlanPercent", description = "완료한 액션 플랜 퍼센트를 구하는 API입니다.")
     public ApiResponse<Integer> getActionPlanPercent(@PathVariable Long memberId) {

--- a/growthookServer/src/main/java/com/example/growthookserver/api/member/controller/MemberController.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/member/controller/MemberController.java
@@ -1,0 +1,31 @@
+package com.example.growthookserver.api.member.controller;
+
+import com.example.growthookserver.api.member.dto.response.MemberDetailGetResponseDto;
+import com.example.growthookserver.api.member.service.MemberService;
+import com.example.growthookserver.common.response.ApiResponse;
+import com.example.growthookserver.common.response.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1")
+@Tag(name = "Member - 유저 관련 API", description = "Member API Document")
+public class MemberController {
+
+  private final MemberService memberService;
+
+  @GetMapping("/member/{memberId}/profile")
+  @ResponseStatus(HttpStatus.OK)
+  @Operation(summary = "MemberProfileGet", description = "멤버 프로필을 조회하는 API입니다.")
+  public ApiResponse<MemberDetailGetResponseDto> getMemberProfile(@PathVariable("memberId") Long memberId) {
+    return ApiResponse.success(SuccessStatus.GET_MEMBER_PROFILE, memberService.getMemberProfile(memberId));
+  }
+}

--- a/growthookServer/src/main/java/com/example/growthookserver/api/member/controller/MemberController.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/member/controller/MemberController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,5 +28,13 @@ public class MemberController {
   @Operation(summary = "MemberProfileGet", description = "멤버 프로필을 조회하는 API입니다.")
   public ApiResponse<MemberDetailGetResponseDto> getMemberProfile(@PathVariable("memberId") Long memberId) {
     return ApiResponse.success(SuccessStatus.GET_MEMBER_PROFILE, memberService.getMemberProfile(memberId));
+  }
+
+  @DeleteMapping("/member/{memberId}")
+  @ResponseStatus(HttpStatus.OK)
+  @Operation(summary = "MemberWithdraw", description = "회원 탈퇴를 하는 API입니다.")
+  public ApiResponse deleteMember(@PathVariable("memberId") Long memberId) {
+    memberService.deleteMember(memberId);
+    return ApiResponse.success(SuccessStatus.DELETE_MEMBER.getStatusCode(), SuccessStatus.DELETE_MEMBER.getMessage());
   }
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/member/domain/Member.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/member/domain/Member.java
@@ -56,4 +56,9 @@ public class Member extends BaseTimeEntity {
     public void incrementGatheredSsuk() {
         this.gatheredSsuk = (this.gatheredSsuk == null ? 0 : this.gatheredSsuk) + 1;
     }
+
+    public void useSsuck() {
+        this.gatheredSsuk--;
+        this.usedSsuk++;
+    }
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/member/dto/response/MemberDetailGetResponseDto.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/member/dto/response/MemberDetailGetResponseDto.java
@@ -1,0 +1,14 @@
+package com.example.growthookserver.api.member.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(staticName = "of")
+public class MemberDetailGetResponseDto {
+  private String nickname;
+  private String email;
+}

--- a/growthookServer/src/main/java/com/example/growthookserver/api/member/service/MemberService.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/member/service/MemberService.java
@@ -6,4 +6,6 @@ public interface MemberService {
   //* 멤버 프로필 정보 조회
   MemberDetailGetResponseDto getMemberProfile(Long memberId);
 
+  //* 회원 탈퇴
+  void deleteMember(Long memberId);
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/member/service/MemberService.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/member/service/MemberService.java
@@ -1,0 +1,9 @@
+package com.example.growthookserver.api.member.service;
+
+import com.example.growthookserver.api.member.dto.response.MemberDetailGetResponseDto;
+
+public interface MemberService {
+  //* 멤버 프로필 정보 조회
+  MemberDetailGetResponseDto getMemberProfile(Long memberId);
+
+}

--- a/growthookServer/src/main/java/com/example/growthookserver/api/member/service/MemberServiceImpl.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/member/service/MemberServiceImpl.java
@@ -19,4 +19,11 @@ public class MemberServiceImpl implements MemberService{
     Member member = memberRepository.findMemberByIdOrThrow(memberId);
     return MemberDetailGetResponseDto.of(member.getNickname(), member.getEmail());
   }
+
+  @Override
+  @Transactional
+  public void deleteMember(Long memberId) {
+    Member member = memberRepository.findMemberByIdOrThrow(memberId);
+    memberRepository.delete(member);
+  }
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/member/service/MemberServiceImpl.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/member/service/MemberServiceImpl.java
@@ -1,0 +1,22 @@
+package com.example.growthookserver.api.member.service;
+
+import com.example.growthookserver.api.member.domain.Member;
+import com.example.growthookserver.api.member.dto.response.MemberDetailGetResponseDto;
+import com.example.growthookserver.api.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberServiceImpl implements MemberService{
+
+  private final MemberRepository memberRepository;
+
+  @Override
+  public MemberDetailGetResponseDto getMemberProfile(Long memberId) {
+    Member member = memberRepository.findMemberByIdOrThrow(memberId);
+    return MemberDetailGetResponseDto.of(member.getNickname(), member.getEmail());
+  }
+}

--- a/growthookServer/src/main/java/com/example/growthookserver/api/review/controller/ReviewController.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/review/controller/ReviewController.java
@@ -36,7 +36,7 @@ public class ReviewController {
 
   @GetMapping("actionplan/{actionPlanId}/review")
   @ResponseStatus(HttpStatus.OK)
-  @Operation(summary = "ReveiwGet", description = "리뷰 상세 조회 API입니다.")
+  @Operation(summary = "ReviewGet", description = "리뷰 상세 조회 API입니다.")
   public ApiResponse<ReviewDetailGetResponseDto> getReviewDetail(@PathVariable("actionPlanId") Long actionPlanId) {
     return ApiResponse.success(SuccessStatus.GET_REVIEW_DETAIL, reviewService.getReviewDetail(actionPlanId));
   }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/review/controller/ReviewController.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/review/controller/ReviewController.java
@@ -1,6 +1,7 @@
 package com.example.growthookserver.api.review.controller;
 
 import com.example.growthookserver.api.review.dto.request.ReviewCreateRequestDto;
+import com.example.growthookserver.api.review.dto.response.ReviewDetailGetResponseDto;
 import com.example.growthookserver.api.review.service.ReviewService;
 import com.example.growthookserver.common.response.ApiResponse;
 import com.example.growthookserver.common.response.SuccessStatus;
@@ -9,6 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -30,5 +32,12 @@ public class ReviewController {
     reviewService.createReview(actionPlanId, reviewCreateRequestDto);
     return ApiResponse.success(
         SuccessStatus.POST_REVIEW_SUCCESS.getStatusCode(), SuccessStatus.POST_REVIEW_SUCCESS.getMessage());
+  }
+
+  @GetMapping("actionplan/{actionPlanId}/review")
+  @ResponseStatus(HttpStatus.OK)
+  @Operation(summary = "ReveiwGet", description = "리뷰 상세 조회 API입니다.")
+  public ApiResponse<ReviewDetailGetResponseDto> getReviewDetail(@PathVariable("actionPlanId") Long actionPlanId) {
+    return ApiResponse.success(SuccessStatus.GET_REVIEW_DETAIL, reviewService.getReviewDetail(actionPlanId));
   }
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/review/controller/ReviewController.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/review/controller/ReviewController.java
@@ -1,0 +1,34 @@
+package com.example.growthookserver.api.review.controller;
+
+import com.example.growthookserver.api.review.dto.request.ReviewCreateRequestDto;
+import com.example.growthookserver.api.review.service.ReviewService;
+import com.example.growthookserver.common.response.ApiResponse;
+import com.example.growthookserver.common.response.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1")
+@Tag(name = "Review - 리뷰 관련 API", description = "Review API Document")
+public class ReviewController {
+
+  private final ReviewService reviewService;
+  @PostMapping("actionplan/{actionPlanId}/review")
+  @ResponseStatus(HttpStatus.CREATED)
+  @Operation(summary = "ReviewPost", description = "리뷰 생성 API입니다.")
+  public ApiResponse createReview(@PathVariable("actionPlanId") Long actionPlanId, @Valid @RequestBody ReviewCreateRequestDto reviewCreateRequestDto) {
+    reviewService.createReview(actionPlanId, reviewCreateRequestDto);
+    return ApiResponse.success(
+        SuccessStatus.POST_REVIEW_SUCCESS.getStatusCode(), SuccessStatus.POST_REVIEW_SUCCESS.getMessage());
+  }
+}

--- a/growthookServer/src/main/java/com/example/growthookserver/api/review/dto/request/ReviewCreateRequestDto.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/review/dto/request/ReviewCreateRequestDto.java
@@ -1,0 +1,17 @@
+package com.example.growthookserver.api.review.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ReviewCreateRequestDto {
+  @NotBlank
+  @Size(max = 300)
+  private String content;
+}

--- a/growthookServer/src/main/java/com/example/growthookserver/api/review/dto/response/ReviewDetailGetResponseDto.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/review/dto/response/ReviewDetailGetResponseDto.java
@@ -1,0 +1,16 @@
+package com.example.growthookserver.api.review.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(staticName = "of")
+public class ReviewDetailGetResponseDto {
+  private String actionPlan;
+  private Boolean isScraped;
+  private String content;
+  private String reviewDate;
+}

--- a/growthookServer/src/main/java/com/example/growthookserver/api/review/repository/ReviewRepository.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/review/repository/ReviewRepository.java
@@ -1,0 +1,8 @@
+package com.example.growthookserver.api.review.repository;
+
+import com.example.growthookserver.api.review.domain.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+}

--- a/growthookServer/src/main/java/com/example/growthookserver/api/review/repository/ReviewRepository.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/review/repository/ReviewRepository.java
@@ -1,8 +1,19 @@
 package com.example.growthookserver.api.review.repository;
 
+import com.example.growthookserver.api.cave.domain.Cave;
 import com.example.growthookserver.api.review.domain.Review;
+import com.example.growthookserver.common.exception.NotFoundException;
+import com.example.growthookserver.common.response.ErrorStatus;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+  Optional<Review> findReviewByActionPlanId(Long actionPlanId);
+
+  default Review findReviewByActionPlanIdOrThrow(Long actionPlanId) {
+    return findReviewByActionPlanId(actionPlanId)
+        .orElseThrow(() -> new NotFoundException(ErrorStatus.NOT_FOUND_REVIEW.getMessage()));
+  }
 
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/review/service/ReviewService.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/review/service/ReviewService.java
@@ -1,0 +1,10 @@
+package com.example.growthookserver.api.review.service;
+
+import com.example.growthookserver.api.review.dto.request.ReviewCreateRequestDto;
+
+public interface ReviewService{
+
+  //* 액션 플랜별 리뷰 작성
+  void createReview(Long actionPlanId, ReviewCreateRequestDto reviewCreateRequestDto);
+
+}

--- a/growthookServer/src/main/java/com/example/growthookserver/api/review/service/ReviewService.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/review/service/ReviewService.java
@@ -1,10 +1,13 @@
 package com.example.growthookserver.api.review.service;
 
 import com.example.growthookserver.api.review.dto.request.ReviewCreateRequestDto;
+import com.example.growthookserver.api.review.dto.response.ReviewDetailGetResponseDto;
 
 public interface ReviewService{
 
   //* 액션 플랜별 리뷰 작성
   void createReview(Long actionPlanId, ReviewCreateRequestDto reviewCreateRequestDto);
 
+  //* 리뷰 내용 상세 조회
+  ReviewDetailGetResponseDto getReviewDetail(Long actionPlanId);
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/review/service/ReviewServiceImpl.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/review/service/ReviewServiceImpl.java
@@ -4,9 +4,10 @@ import com.example.growthookserver.api.actionplan.domain.ActionPlan;
 import com.example.growthookserver.api.actionplan.repository.ActionPlanRepository;
 import com.example.growthookserver.api.review.domain.Review;
 import com.example.growthookserver.api.review.dto.request.ReviewCreateRequestDto;
+import com.example.growthookserver.api.review.dto.response.ReviewDetailGetResponseDto;
 import com.example.growthookserver.api.review.repository.ReviewRepository;
-import com.example.growthookserver.api.seed.domain.Seed;
-import com.example.growthookserver.api.seed.repository.SeedRepository;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,5 +29,18 @@ public class ReviewServiceImpl implements ReviewService {
         .actionPlan(actionPlan)
         .build();
     reviewRepository.save(review);
+  }
+
+  @Override
+  public ReviewDetailGetResponseDto getReviewDetail(Long actionPlanId) {
+    Review review = reviewRepository.findReviewByActionPlanIdOrThrow(actionPlanId);
+    ActionPlan actionPlan = review.getActionPlan();
+    return ReviewDetailGetResponseDto.of(actionPlan.getContent(), actionPlan.getIsScraped(),
+        review.getContent(), formatReviewDate(review.getCreatedAt()));
+  }
+
+  private String formatReviewDate(LocalDateTime reviewDate) {
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+    return reviewDate.format(formatter);
   }
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/review/service/ReviewServiceImpl.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/review/service/ReviewServiceImpl.java
@@ -1,0 +1,32 @@
+package com.example.growthookserver.api.review.service;
+
+import com.example.growthookserver.api.actionplan.domain.ActionPlan;
+import com.example.growthookserver.api.actionplan.repository.ActionPlanRepository;
+import com.example.growthookserver.api.review.domain.Review;
+import com.example.growthookserver.api.review.dto.request.ReviewCreateRequestDto;
+import com.example.growthookserver.api.review.repository.ReviewRepository;
+import com.example.growthookserver.api.seed.domain.Seed;
+import com.example.growthookserver.api.seed.repository.SeedRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReviewServiceImpl implements ReviewService {
+
+  private final ReviewRepository reviewRepository;
+  private final ActionPlanRepository actionPlanRepository;
+
+  @Override
+  @Transactional
+  public void createReview(Long actionPlanId, ReviewCreateRequestDto reviewCreateRequestDto) {
+    ActionPlan actionPlan = actionPlanRepository.findActionPlanByIdOrThrow(actionPlanId);
+    Review review = Review.builder()
+        .content(reviewCreateRequestDto.getContent())
+        .actionPlan(actionPlan)
+        .build();
+    reviewRepository.save(review);
+  }
+}

--- a/growthookServer/src/main/java/com/example/growthookserver/api/seed/controller/SeedController.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/seed/controller/SeedController.java
@@ -94,4 +94,12 @@ public class SeedController {
     return ApiResponse.success(SuccessStatus.GET_SEED_ALARM, seedService.getSeedAlarm(memberId));
   }
 
+  @PatchMapping("seed/{seedId}/lock/status")
+  @ResponseStatus(HttpStatus.OK)
+  @Operation(summary = "unlockSeed", description = "인사이트 잠금을 해제하는 API입니다.")
+  public ApiResponse unlockSeed(@PathVariable Long seedId) {
+    seedService.unlockSeed(seedId);
+    return ApiResponse.success(SuccessStatus.UNLOCK_SEED.getStatusCode(), SuccessStatus.UNLOCK_SEED.getMessage());
+  }
+
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/seed/domain/Seed.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/seed/domain/Seed.java
@@ -74,4 +74,6 @@ public class Seed extends BaseTimeEntity {
     }
 
     public void toggleScrapStatus() { this.isScraped = !this.isScraped; }
+
+    public void unlockSeed() { this.isLocked = false; }
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/api/seed/service/Impl/SeedServiceImpl.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/seed/service/Impl/SeedServiceImpl.java
@@ -4,6 +4,8 @@ import com.example.growthookserver.api.actionplan.domain.ActionPlan;
 import com.example.growthookserver.api.actionplan.repository.ActionPlanRepository;
 import com.example.growthookserver.api.cave.domain.Cave;
 import com.example.growthookserver.api.cave.repository.CaveRepository;
+import com.example.growthookserver.api.member.domain.Member;
+import com.example.growthookserver.api.member.repository.MemberRepository;
 import com.example.growthookserver.api.seed.domain.Seed;
 import com.example.growthookserver.api.seed.dto.request.SeedCreateRequestDto;
 import com.example.growthookserver.api.seed.dto.request.SeedMoveRequestDto;
@@ -35,6 +37,7 @@ public class SeedServiceImpl implements SeedService {
   private final CaveRepository caveRepository;
   private final SeedRepository seedRepository;
   private final ActionPlanRepository actionPlanRepository;
+  private final MemberRepository memberRepository;
 
   @Override
   @Transactional
@@ -123,6 +126,10 @@ public class SeedServiceImpl implements SeedService {
   public void unlockSeed(Long seedId) {
     Seed seed = seedRepository.findSeedByIdOrThrow(seedId);
     seed.unlockSeed();
+
+    Long memberId = seed.getMemberId();
+    Member member = memberRepository.findMemberByIdOrThrow(memberId);
+    member.useSsuck();
   }
 
   @Override

--- a/growthookServer/src/main/java/com/example/growthookserver/api/seed/service/Impl/SeedServiceImpl.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/seed/service/Impl/SeedServiceImpl.java
@@ -120,6 +120,13 @@ public class SeedServiceImpl implements SeedService {
 
   @Override
   @Transactional
+  public void unlockSeed(Long seedId) {
+    Seed seed = seedRepository.findSeedByIdOrThrow(seedId);
+    seed.unlockSeed();
+  }
+
+  @Override
+  @Transactional
   public void toggleSeedScrapStatus(Long seedId) {
     Seed seed = seedRepository.findSeedByIdOrThrow(seedId);
     seed.toggleScrapStatus();

--- a/growthookServer/src/main/java/com/example/growthookserver/api/seed/service/SeedService.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/api/seed/service/SeedService.java
@@ -40,4 +40,6 @@ public interface SeedService {
   //* 씨앗 알림 조회
   SeedAlarmGetResponseDto getSeedAlarm(Long memberId);
 
+  //* 씨앗 잠금 해제
+  void unlockSeed(Long seedId);
 }

--- a/growthookServer/src/main/java/com/example/growthookserver/common/response/ErrorStatus.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/common/response/ErrorStatus.java
@@ -34,6 +34,7 @@ public enum ErrorStatus {
     NOT_FOUND_CAVE("해당하는 동굴이 없습니다."),
     NOT_FOUND_SEED("해당하는 씨앗이 없습니다."),
     NOT_FOUND_ACTIONPLAN("해당하는 액션 플랜이 없습니다."),
+    NOT_FOUND_REVIEW("해당하는 액션플랜에 작성된 리뷰가 없습니다."),
 
     /**
      * 500 SERVER_ERROR

--- a/growthookServer/src/main/java/com/example/growthookserver/common/response/SuccessStatus.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/common/response/SuccessStatus.java
@@ -60,8 +60,8 @@ public enum SuccessStatus {
     /**
      * member
      */
-    GET_MEMBER_PROFILE(HttpStatus.OK, "멤버 프로필 정보 조회 성공"),
-    ;
+    GET_MEMBER_PROFILE(HttpStatus.OK, "회원 프로필 정보 조회 성공"),
+    DELETE_MEMBER(HttpStatus.OK, "회원 탈퇴 성공");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/growthookServer/src/main/java/com/example/growthookserver/common/response/SuccessStatus.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/common/response/SuccessStatus.java
@@ -55,6 +55,7 @@ public enum SuccessStatus {
      * review
      */
     POST_REVIEW_SUCCESS(HttpStatus.CREATED, "리뷰 생성 성공"),
+    GET_REVIEW_DETAIL(HttpStatus.OK, "리뷰 내용 상세 조회 성공"),
     ;
 
     private final HttpStatus httpStatus;

--- a/growthookServer/src/main/java/com/example/growthookserver/common/response/SuccessStatus.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/common/response/SuccessStatus.java
@@ -56,6 +56,11 @@ public enum SuccessStatus {
      */
     POST_REVIEW_SUCCESS(HttpStatus.CREATED, "리뷰 생성 성공"),
     GET_REVIEW_DETAIL(HttpStatus.OK, "리뷰 내용 상세 조회 성공"),
+
+    /**
+     * member
+     */
+    GET_MEMBER_PROFILE(HttpStatus.OK, "멤버 프로필 정보 조회 성공"),
     ;
 
     private final HttpStatus httpStatus;

--- a/growthookServer/src/main/java/com/example/growthookserver/common/response/SuccessStatus.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/common/response/SuccessStatus.java
@@ -37,6 +37,7 @@ public enum SuccessStatus {
     GET_SEED_LIST(HttpStatus.OK, "전체 씨앗 리스트 조회 성공" ),
     TOGGLE_SEED_SCRAP_STATUS(HttpStatus.OK, "씨앗 스크랩 여부 토글 전환 성공"),
     GET_SEED_ALARM(HttpStatus.OK,"씨앗 알람 조회 성공"),
+    UNLOCK_SEED(HttpStatus.OK, "씨앗 잠금 해제 성공"),
 
     /**
      * actionplan

--- a/growthookServer/src/main/java/com/example/growthookserver/common/response/SuccessStatus.java
+++ b/growthookServer/src/main/java/com/example/growthookserver/common/response/SuccessStatus.java
@@ -50,6 +50,11 @@ public enum SuccessStatus {
     GET_FINISHED_ACTIONPLAN_PERCENT(HttpStatus.OK, "완료한 액션 플랜 퍼센트 조회 성공"),
     GET_DOING_ACTIONPLAN_SUCCESS(HttpStatus.OK, "진행 중인 액션 플랜 리스트 조회 성공"),
     GET_FINISHED_ACTIONPLAN_SUCCESS(HttpStatus.OK,"완료한 액션 플랜 리스트 조회 성공"),
+
+    /**
+     * review
+     */
+    POST_REVIEW_SUCCESS(HttpStatus.CREATED, "리뷰 생성 성공"),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #62 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- soft delete가 아니기 때문에 member 테이블에서 해당 유저의 정보가 삭제 되도록 구현했습니다. 연관된 테이블도 cascade 조건을 걸어서 모두 잘 삭제되도록 구현 했습니다.
<img width="1052" alt="image" src="https://github.com/Team-Growthook/Growthook-Server/assets/68415644/91dc59f0-eb3a-48d9-8ba0-b7e89299460e">


## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
